### PR TITLE
Fix toggle-able icons

### DIFF
--- a/src/components/blurry/components/toolbar.jsx
+++ b/src/components/blurry/components/toolbar.jsx
@@ -32,11 +32,11 @@ export default function Toolbar(props) {
             >
                 {props.showImage ? (
                     <>
-                        <span class="underline mr-1">hide image</span>▼
+                        <span class="underline mr-1">hide image</span>▲
                     </>
                 ) : (
                     <>
-                        <span class="underline mr-1">show image</span>▲
+                        <span class="underline mr-1">show image</span>▼
                     </>
                 )}
             </div>

--- a/src/components/navbar/components/theme.jsx
+++ b/src/components/navbar/components/theme.jsx
@@ -21,7 +21,7 @@ export default function Theme() {
 
     return (
         <button onclick={handleTheme} class="mr-2">
-            {!isDarkMode() ? <Light /> : <Dark />}
+            {isDarkMode() ? <Light /> : <Dark />}
         </button>
     );
 }

--- a/src/components/navbar/components/theme.jsx
+++ b/src/components/navbar/components/theme.jsx
@@ -1,17 +1,27 @@
+import { createSignal, createEffect } from "solid-js";
 import Dark from "../../../assets/dark";
 import Light from "../../../assets/light";
 
-export default function Theme(props) {
+export default function Theme() {
+    const [isDarkMode, setIsDarkMode] = createSignal(
+        localStorage.getItem("theme")
+            ? localStorage.getItem("theme") === "dark"
+            : window.matchMedia("(prefers-color-scheme: dark)")
+    );
+
+    createEffect(() => {
+        document.body.classList.add(isDarkMode() ? "dark" : "light");
+        document.body.classList.remove(isDarkMode() ? "light" : "dark");
+    });
+
     const handleTheme = () => {
-        document.body.classList.remove(props.isDarkMode ? "dark" : "light");
-        document.body.classList.add(props.isDarkMode ? "light" : "dark");
-        localStorage.setItem("theme", props.isDarkMode ? "light" : "dark");
-        props.setIsDarkMode(!props.isDarkMode);
+        setIsDarkMode(!isDarkMode());
+        localStorage.setItem("theme", isDarkMode() ? "dark" : "light");
     };
 
     return (
         <button onclick={handleTheme} class="mr-2">
-            {!props.isDarkMode ? <Light /> : <Dark />}
+            {!isDarkMode() ? <Light /> : <Dark />}
         </button>
     );
 }

--- a/src/components/navbar/navbar.jsx
+++ b/src/components/navbar/navbar.jsx
@@ -1,35 +1,13 @@
-import { createSignal, createEffect } from "solid-js";
 import Theme from "./components/theme";
 import Info from "../../assets/info";
 
 export default function NavBar(props) {
-    const [isDarkMode, setIsDarkMode] = createSignal(false);
-
-    createEffect(() => {
-        const selectedTheme = localStorage.getItem("theme");
-
-        if (selectedTheme) {
-            document.body.classList.add(selectedTheme);
-            if (selectedTheme === "light") setIsDarkMode(false);
-            else setIsDarkMode(true);
-        } else if (window.matchMedia("(prefers-color-scheme: dark)").matches) {
-            document.body.classList.add("dark");
-            setIsDarkMode(true);
-            localStorage.setItem("theme", "dark");
-        } else {
-            document.body.classList.add("light");
-        }
-    });
-
     return (
         <navbar class="w-full flex border-b border-primary/20 mb-6">
             <div class="p-4 flex w-full">
                 <h1 class="text-2xl font-bold">bouldle.</h1>
                 <div class="grow" />
-                <Theme
-                    isDarkMode={isDarkMode()}
-                    setIsDarkMode={setIsDarkMode}
-                />
+                <Theme />
                 <button
                     onclick={() => {
                         props.setShowInfo(true);


### PR DESCRIPTION
There are three toggle-able buttons: light/dark toggle, hide/show image, and expand image. Expand image states made sense, but the others indicated opposite actions. This change fixes those to be consistent, and it simplifies the theme toggling code.