### PR TITLE
Persist image settings

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -13,6 +13,7 @@ import Blurry from "./components/blurry/blurry";
 import Results from "./components/results";
 import { setToast, Toast } from "./components/toast";
 import Information from "./components/information/information";
+import createPersisted from "./utilities/createPersisted";
 
 const allowedGuesses = blurAmountList.length;
 const todaysClimb =
@@ -25,21 +26,17 @@ const todaysClimb =
     ];
 
 const firstVisitKey = "firstVisit";
-const todaysKey = String(getCurrentDateFormattedAsInt());
 
 function App() {
-    const [submittedGuesses, setSubmittedGuesses] = createSignal(
-        JSON.parse(localStorage.getItem(todaysKey)) || []
+    const [submittedGuesses, setSubmittedGuesses] = createPersisted(
+        String(getCurrentDateFormattedAsInt()),
+        [],
     );
     const [showDialog, setShowDialog] = createSignal(
         !localStorage[firstVisitKey]
     );
     const [isAnimating, setIsAnimating] = createSignal(false);
     localStorage[firstVisitKey] = new Date().getTime();
-
-    createEffect(() => {
-        localStorage.setItem(todaysKey, JSON.stringify(submittedGuesses()));
-    });
 
     const state = () => {
         const lastGuess = submittedGuesses().at(-1);

--- a/src/components/blurry/blurry.jsx
+++ b/src/components/blurry/blurry.jsx
@@ -1,12 +1,13 @@
 import { createSignal } from "solid-js";
 import { blurAmountList } from "../../utilities/blurAmountList";
 import Toolbar from "./components/toolbar";
+import createPersisted from "../../utilities/createPersisted";
 
 const allowedGuesses = blurAmountList.length;
 
 export default function Blurry(props) {
-    const [showImage, setShowImage] = createSignal(true);
-    const [isExpanded, setIsExpanded] = createSignal(false);
+    const [showImage, setShowImage] = createPersisted("imageShown", true);
+    const [isExpanded, setIsExpanded] = createPersisted("imageExpanded", false);
     return (
         <>
             <div class={`w-full items-center justify-center my-4 flex`}>

--- a/src/utilities/createPersisted.ts
+++ b/src/utilities/createPersisted.ts
@@ -1,0 +1,17 @@
+import { createEffect, createSignal } from "solid-js";
+
+export default function createPersisted<T>(
+    localStorageKey: string,
+    defaultValue: T,
+) {
+    const storedVal = localStorage[localStorageKey];
+    const [value, setValue] = createSignal(
+        storedVal ? (JSON.parse(storedVal) as T) : defaultValue,
+    );
+
+    createEffect(() => {
+        localStorage[localStorageKey] = JSON.stringify(value());
+    });
+
+    return [value, setValue];
+}


### PR DESCRIPTION
Saves whether the image should be shown and expanded to local storage. Also, since this is becoming a common pattern, this adds a `createPersisted` utility.