### PR TITLE
Fix image styling

### DIFF
--- a/src/components/blurry/blurry.jsx
+++ b/src/components/blurry/blurry.jsx
@@ -10,7 +10,7 @@ export default function Blurry(props) {
     return (
         <>
             <div class={`w-full items-center justify-center my-4 flex`}>
-                <div
+                <img
                     class={`pointer-events-none ${
                         showImage() && isExpanded()
                             ? "h-96"
@@ -19,17 +19,13 @@ export default function Blurry(props) {
                             : "h-0"
                     } ${
                         isExpanded() ? "w-96" : "w-60"
-                    } overflow-hidden flex items-center justify-center object-cover shadow-lg transition-dimensions duration-500`}
-                >
-                    <img
-                        class={`min-w-full ${
-                            props.state !== "playing" && !props.isAnimating
-                                ? "blur-[0px]"
-                                : blurAmountList[props.submittedGuessesLength]
-                        }`}
-                        src={props.image}
-                    />
-                </div>
+                    } overflow-hidden flex items-center justify-center shadow-lg transition-dimensions duration-500 object-cover ${
+                        props.state !== "playing" && !props.isAnimating
+                            ? "blur-[0px]"
+                            : blurAmountList[props.submittedGuessesLength]
+                    }`}
+                    src={props.image}
+                ></img>
             </div>
             <Toolbar
                 state={props.state}


### PR DESCRIPTION
Landscape images would look wonky:

![image](https://github.com/wargenng/bouldle/assets/8485687/004574a8-2481-45f1-9610-2d4c1404ec66)

This fixes landscape images to always be cropped correctly.